### PR TITLE
flip to version 3 of the API

### DIFF
--- a/opencnam/opencnam.py
+++ b/opencnam/opencnam.py
@@ -18,7 +18,7 @@ class Phone(object):
     :attr str api_user: Your API username.
     :attr str api_key: Your API key.
     """
-    OPENCNAM_API_URL = 'https://api.opencnam.com/v2/phone/%s'
+    OPENCNAM_API_URL = 'https://api.opencnam.com/v3/phone/%s'
 
     def __init__(self, number, cnam='', api_user=None, api_key=None,
             account_sid=None, auth_token=None):


### PR DESCRIPTION
As documented here:

https://www.opencnam.com/faq/migrating-to-opencnam-v3/how-do-i-switch-to-v3

Switch to v3 of the API.
